### PR TITLE
Fix article attached to unspecific plural nouns.

### DIFF
--- a/src/adjective.ts
+++ b/src/adjective.ts
@@ -63,7 +63,7 @@ export function adjective(template: string): Adjective {
 		articleType?: Article;
 	}) {
 		if (grammaticalNumber === 'p') {
-			if (articleType !== 'none' || grammaticalCase === 'dative')
+			if ((articleType !== 'none' && articleType !== 'indefinite') || grammaticalCase === 'dative')
 				return stem + 'en';
 			if (grammaticalCase === 'nominative' || grammaticalCase === 'accusative')
 				return stem + 'e';

--- a/test/adjective.test.ts
+++ b/test/adjective.test.ts
@@ -79,9 +79,9 @@ test('adjectives decline properly', () => {
 				dative: 'netten',
 			},
 			indefinite: {
-				nominative: 'netten',
-				accusative: 'netten',
-				genitive: 'netten',
+				nominative: 'nette',
+				accusative: 'nette',
+				genitive: 'netter',
 				dative: 'netten',
 			},
 			none: {

--- a/test/noun.test.ts
+++ b/test/noun.test.ts
@@ -198,6 +198,8 @@ test('allows adding adjectives to nouns', () => {
 		.attributes(adjective('klein'))
 		.specific();
 	expect(stone.write()).toBe('der kleine Stein');
+	expect(stone.plural().write()).toBe('die kleinen Steine');
+	expect(stone.plural().unspecific().write()).toBe('kleine Steine');
 
 	const door = noun('die tür,-en,-').attributes('viel zu klein');
 


### PR DESCRIPTION
adjectives added to unspecific plural nouns are not declinated correctly.
E.g. 
```
const stone = noun('der stein,-e,-s').attributes(adjective('klein')).plural().unspecific().write();
```
yields
```
kleinen Steine
```
should be
```
kleine Steine
```

Root cause could be that in ```export type Article = 'indefinite' | 'definite' | 'none' | 'negation';``` 'indefinite' and 'none' are confusing in the singular and plural case. 